### PR TITLE
feat: 단어 퀴즈 API 기본 구조 설계 및 구현

### DIFF
--- a/src/main/java/com/example/remember/RandomWordQuiz/controller/RandomWordQuizController.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/controller/RandomWordQuizController.java
@@ -5,6 +5,8 @@ import com.example.remember.common.type.quiz.QuizSuccessCode;
 import com.example.remember.RandomWordQuiz.dto.RandomWordRequest;
 import com.example.remember.RandomWordQuiz.dto.RandomWordResponse;
 import com.example.remember.RandomWordQuiz.service.RandomWordQuizService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +21,7 @@ public class RandomWordQuizController {
 
     @GetMapping("/random")
     public ApiResponse<RandomWordResponse> randomByQuery(
-            @RequestParam(defaultValue = "3") Integer length
+            @RequestParam(defaultValue = "3") @Min(1) @Max(20) Integer length
     ) {
         RandomWordRequest randomWordRequest = new RandomWordRequest("ko", length, "noun");
         return ApiResponse.success(QuizSuccessCode.WORD_GENERATED, randomWordQuizService.generate(randomWordRequest));

--- a/src/main/java/com/example/remember/RandomWordQuiz/controller/RandomWordQuizController.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/controller/RandomWordQuizController.java
@@ -1,0 +1,27 @@
+package com.example.remember.RandomWordQuiz.controller;
+
+import com.example.remember.common.dto.response.ApiResponse;
+import com.example.remember.common.type.quiz.QuizSuccessCode;
+import com.example.remember.RandomWordQuiz.dto.RandomWordRequest;
+import com.example.remember.RandomWordQuiz.dto.RandomWordResponse;
+import com.example.remember.RandomWordQuiz.service.RandomWordQuizService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/words")
+@RequiredArgsConstructor
+public class RandomWordQuizController {
+    private final RandomWordQuizService randomWordQuizService;
+
+    @GetMapping("/random")
+    public ApiResponse<RandomWordResponse> randomByQuery(
+            @RequestParam(defaultValue = "3") Integer length
+    ) {
+        RandomWordRequest randomWordRequest = new RandomWordRequest("ko", length, "noun");
+        return ApiResponse.success(QuizSuccessCode.WORD_GENERATED, randomWordQuizService.generate(randomWordRequest));
+    }
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/dto/RandomWordRequest.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/dto/RandomWordRequest.java
@@ -1,0 +1,8 @@
+package com.example.remember.RandomWordQuiz.dto;
+
+public record RandomWordRequest(
+        String lang,
+        int length,
+        String pos
+) {
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/dto/RandomWordResponse.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/dto/RandomWordResponse.java
@@ -1,0 +1,11 @@
+package com.example.remember.RandomWordQuiz.dto;
+
+import java.util.List;
+
+public record RandomWordResponse(
+        List<String> words,
+        String lang,
+        Integer length,
+        String pos
+) {
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/entity/WordGenerationLog.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/entity/WordGenerationLog.java
@@ -1,0 +1,29 @@
+package com.example.remember.RandomWordQuiz.entity;
+
+import jakarta.persistence.*;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "word_generation_log")
+public class WordGenerationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String word;
+    private String lang;
+    private Integer length;
+    private String pos;
+
+    @Column(length = 1000)
+    private String prompt;
+
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    public void onCreate() {
+        if (createdAt == null) createdAt = OffsetDateTime.now();
+    }
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/entity/WordGenerationLog.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/entity/WordGenerationLog.java
@@ -10,7 +10,7 @@ public class WordGenerationLog {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     private String word;
     private String lang;
@@ -19,11 +19,4 @@ public class WordGenerationLog {
 
     @Column(length = 1000)
     private String prompt;
-
-    private OffsetDateTime createdAt;
-
-    @PrePersist
-    public void onCreate() {
-        if (createdAt == null) createdAt = OffsetDateTime.now();
-    }
 }

--- a/src/main/java/com/example/remember/RandomWordQuiz/implement/GptRandomWordParser.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/implement/GptRandomWordParser.java
@@ -1,6 +1,6 @@
 package com.example.remember.RandomWordQuiz.implement;
 
-import com.example.remember.common.exception.InternationalServerException;
+import com.example.remember.common.exception.InternalServerException;
 import com.example.remember.common.type.quiz.QuizErrorCode;
 import com.example.remember.gpt.dto.GPTResponseDto;
 import com.example.remember.RandomWordQuiz.dto.RandomWordResponse;
@@ -17,11 +17,10 @@ public class GptRandomWordParser {
 
     public RandomWordResponse toRandomWordResponse(GPTResponseDto gptResponseDto) {
         String json = extractText(gptResponseDto);
-        System.out.println(json);
         try {
             return objectMapper.readValue(json, RandomWordResponse.class);
         } catch (Exception e) {
-            throw new InternationalServerException(QuizErrorCode.WORD_PARSING_FAILED);
+            throw new InternalServerException(QuizErrorCode.WORD_PARSING_FAILED);
         }
     }
 
@@ -42,6 +41,6 @@ public class GptRandomWordParser {
                 }
             }
         }
-        throw new InternationalServerException(QuizErrorCode.WORD_GENERATION_FAILED);
+        throw new InternalServerException(QuizErrorCode.WORD_GENERATION_FAILED);
     }
 }

--- a/src/main/java/com/example/remember/RandomWordQuiz/implement/GptRandomWordParser.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/implement/GptRandomWordParser.java
@@ -1,0 +1,47 @@
+package com.example.remember.RandomWordQuiz.implement;
+
+import com.example.remember.common.exception.InternationalServerException;
+import com.example.remember.common.type.quiz.QuizErrorCode;
+import com.example.remember.gpt.dto.GPTResponseDto;
+import com.example.remember.RandomWordQuiz.dto.RandomWordResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GptRandomWordParser {
+    private final ObjectMapper objectMapper;
+
+    public RandomWordResponse toRandomWordResponse(GPTResponseDto gptResponseDto) {
+        String json = extractText(gptResponseDto);
+        System.out.println(json);
+        try {
+            return objectMapper.readValue(json, RandomWordResponse.class);
+        } catch (Exception e) {
+            throw new InternationalServerException(QuizErrorCode.WORD_PARSING_FAILED);
+        }
+    }
+
+    private String extractText(GPTResponseDto gptResponseDto) {
+        List<GPTResponseDto.Out> outs = gptResponseDto.output();
+        if (outs != null) {
+            for (GPTResponseDto.Out out : outs) {
+                if (out == null || out.content() == null) continue;
+                for (GPTResponseDto.Content c : out.content()) {
+                    if (c == null) continue;
+                    String type = c.type();
+                    if ("output_text".equals(type) || "text".equals(type)) {
+                        String t = c.text();
+                        if (t != null && !t.isBlank()) {
+                            return t.trim();
+                        }
+                    }
+                }
+            }
+        }
+        throw new InternationalServerException(QuizErrorCode.WORD_GENERATION_FAILED);
+    }
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/implement/PromptProvider.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/implement/PromptProvider.java
@@ -6,7 +6,7 @@ public final class PromptProvider {
     private PromptProvider() {
     }
 
-    public static String JsonSingleWordPrompt(RandomWordRequest req, int count) {
+    public static String jsonSingleWordPrompt(RandomWordRequest req, int count) {
         String lang = "ko";    // 고정
         String pos = "noun";  // 고정
 

--- a/src/main/java/com/example/remember/RandomWordQuiz/implement/PromptProvider.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/implement/PromptProvider.java
@@ -1,0 +1,33 @@
+package com.example.remember.RandomWordQuiz.implement;
+
+import com.example.remember.RandomWordQuiz.dto.RandomWordRequest;
+
+public final class PromptProvider {
+    private PromptProvider() {
+    }
+
+    public static String JsonSingleWordPrompt(RandomWordRequest req, int count) {
+        String lang = "ko";    // 고정
+        String pos = "noun";  // 고정
+
+        return """
+                You are a word generator.
+                
+                Requirements:
+                - Generate %d unique words (no duplicates).
+                - Language: %s
+                - Part of speech: %s
+                - Each word MUST be exactly %d Korean syllable characters (Hangul, U+AC00–U+D7A3).
+                - No English letters, no numbers, no symbols.
+                - Words must be commonly used and valid in the specified language.
+                - No profanity, no named entities, no rare/obsolete words.
+                Output:
+                - Return ONLY a strict JSON object. No markdown, no code fences, no extra text.
+                
+                JSON shape (exact keys):
+                {
+                  "words": ["<word1>", "<word2>", "..."]
+                }
+                """.formatted(count, lang, pos, req.length());
+    }
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/repository/WordGenerationLogRepository.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/repository/WordGenerationLogRepository.java
@@ -1,0 +1,7 @@
+package com.example.remember.RandomWordQuiz.repository;
+
+import com.example.remember.RandomWordQuiz.entity.WordGenerationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WordGenerationLogRepository extends JpaRepository<WordGenerationLog, Long> {
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/service/RandomWordQuizService.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/service/RandomWordQuizService.java
@@ -1,0 +1,8 @@
+package com.example.remember.RandomWordQuiz.service;
+
+import com.example.remember.RandomWordQuiz.dto.RandomWordRequest;
+import com.example.remember.RandomWordQuiz.dto.RandomWordResponse;
+
+public interface RandomWordQuizService {
+    RandomWordResponse generate(RandomWordRequest request);
+}

--- a/src/main/java/com/example/remember/RandomWordQuiz/service/RandomWordQuizServiceImpl.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/service/RandomWordQuizServiceImpl.java
@@ -1,5 +1,8 @@
 package com.example.remember.RandomWordQuiz.service;
 
+import com.example.remember.common.exception.BaseException;
+import com.example.remember.common.exception.InternalServerException;
+import com.example.remember.common.type.quiz.QuizErrorCode;
 import com.example.remember.gpt.dto.GPTResponseDto;
 import com.example.remember.gpt.service.ChatGPTService;
 import com.example.remember.RandomWordQuiz.dto.RandomWordRequest;
@@ -22,20 +25,25 @@ public class RandomWordQuizServiceImpl implements RandomWordQuizService {
 
         RandomWordResponse data = null;
 
-        for (int attempt = 0; attempt < maxRetry && data == null; attempt++) {
-            String prompt = PromptProvider.JsonSingleWordPrompt(request, 10);
-            GPTResponseDto responseDto = chatGPTService.chat(prompt);
-
-            // GPT 응답에서 JSON 텍스트를 꺼내고 → 우리 도메인 DTO로 파싱
-            data = gptRandomWordParser.toRandomWordResponse(responseDto);
+        for (int attempt = 1; attempt <= maxRetry && data == null; attempt++) {
+            try {
+                String prompt = PromptProvider.jsonSingleWordPrompt(request, 10);
+                GPTResponseDto responseDto = chatGPTService.chat(prompt);
+                // GPT 응답에서 JSON 텍스트를 꺼내고 → 우리 도메인 DTO로 파싱
+                data = gptRandomWordParser.toRandomWordResponse(responseDto);
+            } catch (Exception e) {
+                throw new InternalServerException(QuizErrorCode.WORD_GENERATION_FAILED);
+            }
         }
 
-        data = new RandomWordResponse(
+        if (data == null) {
+            throw new InternalServerException(QuizErrorCode.WORD_GENERATION_FAILED);
+        }
+        return new RandomWordResponse(
                 data.words(),
                 request.lang(),
                 request.length(),
                 request.pos()
         );
-        return data;
     }
 }

--- a/src/main/java/com/example/remember/RandomWordQuiz/service/RandomWordQuizServiceImpl.java
+++ b/src/main/java/com/example/remember/RandomWordQuiz/service/RandomWordQuizServiceImpl.java
@@ -1,0 +1,41 @@
+package com.example.remember.RandomWordQuiz.service;
+
+import com.example.remember.gpt.dto.GPTResponseDto;
+import com.example.remember.gpt.service.ChatGPTService;
+import com.example.remember.RandomWordQuiz.dto.RandomWordRequest;
+import com.example.remember.RandomWordQuiz.dto.RandomWordResponse;
+import com.example.remember.RandomWordQuiz.implement.GptRandomWordParser;
+import com.example.remember.RandomWordQuiz.implement.PromptProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RandomWordQuizServiceImpl implements RandomWordQuizService {
+
+    private final ChatGPTService chatGPTService;
+    private final GptRandomWordParser gptRandomWordParser;
+
+    @Override
+    public RandomWordResponse generate(RandomWordRequest request) {
+        final int maxRetry = 2;
+
+        RandomWordResponse data = null;
+
+        for (int attempt = 0; attempt < maxRetry && data == null; attempt++) {
+            String prompt = PromptProvider.JsonSingleWordPrompt(request, 10);
+            GPTResponseDto responseDto = chatGPTService.chat(prompt);
+
+            // GPT 응답에서 JSON 텍스트를 꺼내고 → 우리 도메인 DTO로 파싱
+            data = gptRandomWordParser.toRandomWordResponse(responseDto);
+        }
+
+        data = new RandomWordResponse(
+                data.words(),
+                request.lang(),
+                request.length(),
+                request.pos()
+        );
+        return data;
+    }
+}

--- a/src/main/java/com/example/remember/common/exception/BaseException.java
+++ b/src/main/java/com/example/remember/common/exception/BaseException.java
@@ -13,16 +13,16 @@ public class BaseException extends RuntimeException {
         this.httpStatus = httpStatus;
     }
 
-    public HttpStatus getHttpStatus() {
-        return this.httpStatus;
-    }
-
     public int getHttpCode() {
         return this.httpStatus.value();
     }
 
     public ErrorType getErrorType() {
         return this.errorType;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
     }
 }
 

--- a/src/main/java/com/example/remember/common/exception/InternalServerException.java
+++ b/src/main/java/com/example/remember/common/exception/InternalServerException.java
@@ -3,8 +3,8 @@ package com.example.remember.common.exception;
 import com.example.remember.common.type.ErrorType;
 import org.springframework.http.HttpStatus;
 
-public class InternationalServerException extends BaseException{
-    public InternationalServerException(ErrorType errorType) {
+public class InternalServerException extends BaseException{
+    public InternalServerException(ErrorType errorType) {
         super(errorType, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/example/remember/common/exception/InternationalServerException.java
+++ b/src/main/java/com/example/remember/common/exception/InternationalServerException.java
@@ -1,0 +1,10 @@
+package com.example.remember.common.exception;
+
+import com.example.remember.common.type.ErrorType;
+import org.springframework.http.HttpStatus;
+
+public class InternationalServerException extends BaseException{
+    public InternationalServerException(ErrorType errorType) {
+        super(errorType, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/example/remember/common/type/quiz/QuizErrorCode.java
+++ b/src/main/java/com/example/remember/common/type/quiz/QuizErrorCode.java
@@ -1,0 +1,27 @@
+package com.example.remember.common.type.quiz;
+
+import com.example.remember.common.type.ErrorType;
+
+public enum QuizErrorCode implements ErrorType {
+    WORD_GENERATION_FAILED(500, "서버 내부 오류입니다."),
+    WORD_PARSING_FAILED(500, "GPT 응답 JSON 파싱 실패입니다."),
+    WORD_TEXT_NOT_FOUND(500, "GPT 응답에서 텍스트를 찾을 수 없습니다");
+
+    QuizErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    private final int code;
+    private final String message;
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/example/remember/common/type/quiz/QuizSuccessCode.java
+++ b/src/main/java/com/example/remember/common/type/quiz/QuizSuccessCode.java
@@ -1,0 +1,30 @@
+package com.example.remember.common.type.quiz;
+
+import com.example.remember.common.dto.response.ApiResponse;
+import com.example.remember.common.type.SuccessType;
+
+public enum QuizSuccessCode implements SuccessType {
+    WORD_GENERATED(200, "단어 생성 성공");
+
+    private final int code;
+    private final String message;
+
+    QuizSuccessCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public <T>ApiResponse<T> toResponse(T data){
+        return new ApiResponse<>(code, message, data);
+    }
+}

--- a/src/main/java/com/example/remember/gpt/dto/GPTRequestDto.java
+++ b/src/main/java/com/example/remember/gpt/dto/GPTRequestDto.java
@@ -1,7 +1,5 @@
 package com.example.remember.gpt.dto;
 
-import java.util.List;
-
 public record GPTRequestDto(
         String model,
         String input,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,4 +10,4 @@ spring:
       prod1: prod1, gpt
       prod2: prod2, gpt
       local: local, gpt
-    active: prod2
+    active: local


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 랜덤 단어 퀴즈 API 추가: /api/words/random에서 한국어 명사 후보를 반환합니다. length 파라미터(기본 3, 1~20 허용)로 글자 수를 지정할 수 있으며, 응답에는 단어 목록과 언어/길이/품사 정보가 포함됩니다. 오류 상황은 일관된 응답 형식으로 전달됩니다.
- 잡무
  - 기본 실행 프로필을 local로 변경해 로컬 환경 기본값을 개선했습니다.
  - 불필요한 import를 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->